### PR TITLE
Add .NET 10 / EF Core 10 target framework

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,10 +17,11 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: | 
+        dotnet-version: |
           3.1.x
           6.0.x
           8.0.x
+          10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/src/providers/WorkflowCore.Persistence.EntityFramework/WorkflowCore.Persistence.EntityFramework.csproj
+++ b/src/providers/WorkflowCore.Persistence.EntityFramework/WorkflowCore.Persistence.EntityFramework.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Workflow Core EntityFramework Core Persistence Provider</AssemblyTitle>
     <Authors>DanielGerlag,sergiikram</Authors>
-    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.Persistence.EntityFramework</AssemblyName>
     <PackageId>SergiiKram.WorkflowCore.Persistence.EntityFramework</PackageId>
     <PackageTags>idempotent;workflow;.NET;Core;state machine;WorkflowCore;EntityFramework;EntityFrameworkCore</PackageTags>
@@ -27,6 +27,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.*" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">

--- a/src/providers/WorkflowCore.Persistence.PostgreSQL/WorkflowCore.Persistence.PostgreSQL.csproj
+++ b/src/providers/WorkflowCore.Persistence.PostgreSQL/WorkflowCore.Persistence.PostgreSQL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Workflow Core Idempotent PostgreSQL Persistence Provider</AssemblyTitle>
     <Authors>DanielGerlag,sergiikram</Authors>
-    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0;net10.0</TargetFrameworks>
     <AssemblyName>WorkflowCore.Persistence.PostgreSQL</AssemblyName>
     <PackageId>SergiiKram.WorkflowCore.Persistence.PostgreSQL</PackageId>
     <PackageTags>idempotent;workflow;.NET;Core;state machine;WorkflowCore;PostgreSQL</PackageTags>
@@ -41,6 +41,18 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Npgsql" Version="10.*" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.*">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/WorkflowCore.Tests.PostgreSQL/WorkflowCore.Tests.PostgreSQL.csproj
+++ b/test/WorkflowCore.Tests.PostgreSQL/WorkflowCore.Tests.PostgreSQL.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>WorkflowCore.Tests.PostgreSQL</AssemblyName>
     <PackageId>WorkflowCore.Tests.PostgreSQL</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
## Summary

Adds a `net10.0` target framework to the two EntityFramework-based provider projects so that consumers on .NET 10 / EF Core 10 can bind against the correct `ExecuteDeleteAsync` API.

## Motivation

Consuming the published `3.9.0.7` packages (net8 target) from a .NET 10 / EF Core 10 project throws at runtime when `WorkflowPurger` runs:

```
System.MissingMethodException: Method not found:
  'System.Threading.Tasks.Task`1<Int32>
   Microsoft.EntityFrameworkCore.RelationalQueryableExtensions.ExecuteDeleteAsync(
       System.Linq.IQueryable`1<!!0>, System.Threading.CancellationToken)'.
    at WorkflowCore.Persistence.EntityFramework.Services.WorkflowPurger.PurgeWorkflows(...)
```

EF Core 10 moved `ExecuteDelete[Async]` / `ExecuteUpdate[Async]` off `RelationalQueryableExtensions` (`Microsoft.EntityFrameworkCore.Relational`) onto `EntityFrameworkQueryableExtensions` (`Microsoft.EntityFrameworkCore`), because those operators now have non-relational implementations too. The net8 assembly's hardcoded MethodRef no longer resolves under EF Core 10.

Adding a `net10.0` TFM with `Microsoft.EntityFrameworkCore.Relational 10.*` / `Npgsql(.EntityFrameworkCore.PostgreSQL) 10.*` makes the compiler emit the new MethodRef for net10 consumers, while net6/net8 builds are unchanged.

## Scope

Only the two EntityFramework-based providers need a `net10.0` target. The broken `ExecuteDeleteAsync` call lives inside `WorkflowCore.Persistence.EntityFramework`'s compiled IL; sibling providers (MySQL, SqlServer, Sqlite) only reference types from it and don't emit any broken MethodRefs themselves — they pick up the fix transitively through the `Persistence.EntityFramework` `net10.0` asset. All other packages ship as `netstandard2.0`, which is a strict subset of .NET 10's surface and is unaffected.

## Changes

- `WorkflowCore.Persistence.EntityFramework.csproj` — add `net10.0` to `TargetFrameworks`; conditional `Microsoft.EntityFrameworkCore.Relational` `10.*` reference.
- `WorkflowCore.Persistence.PostgreSQL.csproj` — add `net10.0` to `TargetFrameworks`; conditional `Npgsql`, `Npgsql.EntityFrameworkCore.PostgreSQL`, `Microsoft.EntityFrameworkCore.Tools`, `Microsoft.EntityFrameworkCore.Design` `10.*` references.
- `.github/workflows/dotnet.yml` — pin runner to `ubuntu-22.04` (Ubuntu 24.04 on `ubuntu-latest` removed `libssl1.1`, which is still required by the `netcoreapp3.1` / older-`net6.0` testhosts; a longer-term cleanup is to drop EOL TFMs from `test/Directory.Build.props`, out of scope here); add `10.0.x` to `setup-dotnet` so the new `net10.0` build step has an explicit SDK rather than relying on whatever the runner image happens to preinstall.

No package version bumps, no library source changes.

## Verification

- Packed locally as `3.9.0.8-net10`, consumed from a .NET 10 app running EF Core 10.0.6 against PostgreSQL — `IWorkflowPurger.PurgeWorkflows` succeeds end-to-end.
- Same app with the published `3.9.0.7` reproduces the `MissingMethodException` above.
- CI green on this PR after the `ubuntu-22.04` pin and `10.0.x` SDK addition.