### PR TITLE
Align DSL with upstream danielgerlag/workflow-core

### DIFF
--- a/src/WorkflowCore.DSL/Interface/ITypeResolver.cs
+++ b/src/WorkflowCore.DSL/Interface/ITypeResolver.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Linq;
+
+namespace WorkflowCore.Interface
+{
+    public interface ITypeResolver
+    {
+        Type FindType(string name);
+    }
+}

--- a/src/WorkflowCore.DSL/ServiceCollectionExtensions.cs
+++ b/src/WorkflowCore.DSL/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddWorkflowDSL(this IServiceCollection services)
         {
+            services.AddTransient<ITypeResolver, TypeResolver>();
             services.AddTransient<IDefinitionLoader, DefinitionLoader>();
             return services;
         }

--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Dynamic.Core;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 using WorkflowCore.Interface;
 using WorkflowCore.Models;
@@ -17,15 +18,59 @@ namespace WorkflowCore.Services.DefinitionStorage
     public class DefinitionLoader : IDefinitionLoader
     {
         private readonly IWorkflowRegistry _registry;
+        private readonly ITypeResolver _typeResolver;
 
-        public DefinitionLoader(IWorkflowRegistry registry)
+        // ParsingConfig to allow access to commonly used .NET methods like object.Equals
+        private static readonly ParsingConfig ParsingConfig = new ParsingConfig
+        {
+            AllowNewToEvaluateAnyType = false,
+            AreContextKeywordsEnabled = true
+        };
+
+        // Transform expressions to be compatible with System.Linq.Dynamic.Core 1.6.0+
+        private static string TransformExpression(string expression)
+        {
+            if (string.IsNullOrEmpty(expression))
+                return expression;
+
+            // Transform object.Equals(a, b) to Convert.ToBoolean(a) == Convert.ToBoolean(b)
+            // This is a simple regex replacement for the common pattern
+            var objectEqualsPattern = @"object\.Equals\s*\(\s*([^,]+)\s*,\s*([^)]+)\s*\)";
+            var transformed = Regex.Replace(expression, objectEqualsPattern,
+                match =>
+                {
+                    var arg1 = match.Groups[1].Value.Trim();
+                    var arg2 = match.Groups[2].Value.Trim();
+
+                    // If arg2 is a boolean literal, convert arg1 to boolean and compare
+                    if (arg2 == "true" || arg2 == "false")
+                    {
+                        return $"Convert.ToBoolean({arg1}) == {arg2}";
+                    }
+                    // Otherwise, convert both to strings for comparison
+                    return $"Convert.ToString({arg1}) == Convert.ToString({arg2})";
+                });
+
+            return transformed;
+        }
+
+        public DefinitionLoader(IWorkflowRegistry registry, ITypeResolver typeResolver)
         {
             _registry = registry;
+            _typeResolver = typeResolver;
         }
 
         public WorkflowDefinition LoadDefinition(string source, Func<string, DefinitionSourceV1> deserializer)
         {
+            if (string.IsNullOrWhiteSpace(source))
+                throw new ArgumentNullException(nameof(source));
+            if (deserializer == null)
+                throw new ArgumentNullException(nameof(deserializer));
+
             var sourceObj = deserializer(source);
+            if (sourceObj == null)
+                throw new InvalidOperationException("Deserialization returned null.");
+
             var def = Convert(sourceObj);
             _registry.RegisterWorkflow(def);
             return def;
@@ -73,11 +118,17 @@ namespace WorkflowCore.Services.DefinitionStorage
                 {
                     containerType = typeof(WorkflowStep<>).MakeGenericType(stepType);
 
-                    targetStep = (containerType.GetConstructor(new Type[] { }).Invoke(null) as WorkflowStep);
+                    var ctor = containerType.GetConstructor(new Type[] { });
+                    if (ctor == null)
+                        throw new InvalidOperationException($"Type '{containerType.FullName}' does not have a parameterless constructor.");
+                    targetStep = ctor.Invoke(null) as WorkflowStep;
                 }
                 else
                 {
-                    targetStep = stepType.GetConstructor(new Type[] { }).Invoke(null) as WorkflowStep;
+                    var ctor = stepType.GetConstructor(new Type[] { });
+                    if (ctor == null)
+                        throw new InvalidOperationException($"Type '{stepType.FullName}' does not have a parameterless constructor.");
+                    targetStep = ctor.Invoke(null) as WorkflowStep;
                     if (targetStep != null)
                         stepType = targetStep.BodyType;
                 }
@@ -85,15 +136,25 @@ namespace WorkflowCore.Services.DefinitionStorage
                 if (nextStep.Saga)
                 {
                     containerType = typeof(SagaContainer<>).MakeGenericType(stepType);
-                    targetStep = (containerType.GetConstructor(new Type[] { }).Invoke(null) as WorkflowStep);
+                    var sagaCtor = containerType.GetConstructor(new Type[] { });
+                    if (sagaCtor == null)
+                        throw new InvalidOperationException($"Type '{containerType.FullName}' does not have a parameterless constructor.");
+                    targetStep = sagaCtor.Invoke(null) as WorkflowStep;
                 }
 
                 if (!string.IsNullOrEmpty(nextStep.CancelCondition))
                 {
                     var cancelExprType = typeof(Expression<>).MakeGenericType(typeof(Func<,>).MakeGenericType(dataType, typeof(bool)));
                     var dataParameter = Expression.Parameter(dataType, "data");
-                    var cancelExpr = DynamicExpressionParser.ParseLambda(new[] { dataParameter }, typeof(bool), nextStep.CancelCondition);
-                    targetStep.CancelCondition = cancelExpr;
+                    try
+                    {
+                        var cancelExpr = DynamicExpressionParser.ParseLambda(ParsingConfig, false, new[] { dataParameter }, typeof(bool), TransformExpression(nextStep.CancelCondition));
+                        targetStep.CancelCondition = cancelExpr;
+                    }
+                    catch (Exception ex) when (ex is System.Linq.Dynamic.Core.Exceptions.ParseException || ex is InvalidOperationException)
+                    {
+                        throw new WorkflowDefinitionLoadException($"Error parsing cancel condition expression '{nextStep.CancelCondition}' for step '{nextStep.Id}': {ex.Message}", ex);
+                    }
                 }
 
                 targetStep.Id = i;
@@ -215,15 +276,24 @@ namespace WorkflowCore.Services.DefinitionStorage
             foreach (var output in source.Outputs)
             {
                 var stepParameter = Expression.Parameter(stepType, "step");
-                var sourceExpr = DynamicExpressionParser.ParseLambda(new[] { stepParameter }, typeof(object), output.Value);
+                LambdaExpression sourceExpr;
+                try
+                {
+                    sourceExpr = DynamicExpressionParser.ParseLambda(ParsingConfig, false, new[] { stepParameter }, typeof(object), TransformExpression(output.Value));
+                }
+                catch (Exception ex) when (ex is System.Linq.Dynamic.Core.Exceptions.ParseException || ex is InvalidOperationException)
+                {
+                    throw new WorkflowDefinitionLoadException($"Error parsing output expression '{output.Value}': {ex.Message}", ex);
+                }
 
                 var dataParameter = Expression.Parameter(dataType, "data");
 
 
-                if(output.Key.Contains(".") || output.Key.Contains("["))
+                if (output.Key.Contains(".") || output.Key.Contains("["))
                 {
                     AttachNestedOutput(output, step, source, sourceExpr, dataParameter);
-                }else
+                }
+                else
                 {
                     AttachDirectlyOutput(output, step, dataType, sourceExpr, dataParameter);
                 }
@@ -250,7 +320,15 @@ namespace WorkflowCore.Services.DefinitionStorage
 
                 Action<IStepBody, object> acn = (pStep, pData) =>
                 {
-                    object resolvedValue = sourceExpr.Compile().DynamicInvoke(pStep); ;
+                    object resolvedValue;
+                    try
+                    {
+                        resolvedValue = sourceExpr.Compile().DynamicInvoke(pStep);
+                    }
+                    catch (TargetInvocationException ex)
+                    {
+                        throw new InvalidOperationException($"Error evaluating expression for output property.", ex.InnerException ?? ex);
+                    }
                     propertyInfo.SetValue(pData, resolvedValue, new object[] { output.Key });
                 };
 
@@ -259,11 +337,11 @@ namespace WorkflowCore.Services.DefinitionStorage
 
         }
 
-        private void AttachNestedOutput( KeyValuePair<string, string> output, WorkflowStep step, StepSourceV1 source, LambdaExpression sourceExpr, ParameterExpression dataParameter)
+        private void AttachNestedOutput(KeyValuePair<string, string> output, WorkflowStep step, StepSourceV1 source, LambdaExpression sourceExpr, ParameterExpression dataParameter)
         {
             PropertyInfo propertyInfo = null;
             String[] paths = output.Key.Split('.');
-         
+
             Expression targetProperty = dataParameter;
 
             bool hasAddOutput = false;
@@ -302,8 +380,24 @@ namespace WorkflowCore.Services.DefinitionStorage
                     Action<IStepBody, object> acn = (pStep, pData) =>
                     {
                         var targetExpr = Expression.Lambda(memberExpression, dataParameter);
-                        object data = targetExpr.Compile().DynamicInvoke(pData);
-                        object resolvedValue = sourceExpr.Compile().DynamicInvoke(pStep); ;
+                        object data;
+                        try
+                        {
+                            data = targetExpr.Compile().DynamicInvoke(pData);
+                        }
+                        catch (TargetInvocationException ex)
+                        {
+                            throw new InvalidOperationException($"Error evaluating expression for nested output property.", ex.InnerException ?? ex);
+                        }
+                        object resolvedValue;
+                        try
+                        {
+                            resolvedValue = sourceExpr.Compile().DynamicInvoke(pStep);
+                        }
+                        catch (TargetInvocationException ex)
+                        {
+                            throw new InvalidOperationException($"Error evaluating expression for nested output property.", ex.InnerException ?? ex);
+                        }
                         propertyInfo.SetValue(data, resolvedValue, new object[] { items[1] });
                     };
 
@@ -316,7 +410,7 @@ namespace WorkflowCore.Services.DefinitionStorage
                     {
                         targetProperty = Expression.Property(targetProperty, propertyName);
                     }
-                    catch
+                    catch (ArgumentException)
                     {
                         targetProperty = null;
                         break;
@@ -341,7 +435,15 @@ namespace WorkflowCore.Services.DefinitionStorage
 
             foreach (var nextStep in source.SelectNextStep)
             {
-                var sourceDelegate = DynamicExpressionParser.ParseLambda(new[] { dataParameter, outcomeParameter }, typeof(object), nextStep.Value).Compile();
+                Delegate sourceDelegate;
+                try
+                {
+                    sourceDelegate = DynamicExpressionParser.ParseLambda(ParsingConfig, false, new[] { dataParameter, outcomeParameter }, typeof(object), TransformExpression(nextStep.Value)).Compile();
+                }
+                catch (Exception ex) when (ex is System.Linq.Dynamic.Core.Exceptions.ParseException || ex is InvalidOperationException)
+                {
+                    throw new WorkflowDefinitionLoadException($"Error parsing select next step expression '{nextStep.Value}': {ex.Message}", ex);
+                }
                 Expression<Func<object, object, bool>> sourceExpr = (data, outcome) => System.Convert.ToBoolean(sourceDelegate.DynamicInvoke(data, outcome));
                 step.Outcomes.Add(new ExpressionOutcome<object>(sourceExpr)
                 {
@@ -352,19 +454,44 @@ namespace WorkflowCore.Services.DefinitionStorage
 
         private Type FindType(string name)
         {
-            return Type.GetType(name, true, true);
+            return _typeResolver.FindType(name);
         }
 
         private static Action<IStepBody, object, IStepExecutionContext> BuildScalarInputAction(KeyValuePair<string, object> input, ParameterExpression dataParameter, ParameterExpression contextParameter, ParameterExpression environmentVarsParameter, PropertyInfo stepProperty)
         {
             var expr = System.Convert.ToString(input.Value);
-            var sourceExpr = DynamicExpressionParser.ParseLambda(new[] { dataParameter, contextParameter, environmentVarsParameter }, typeof(object), expr);
+            LambdaExpression sourceExpr;
+            try
+            {
+                sourceExpr = DynamicExpressionParser.ParseLambda(ParsingConfig, false, new[] { dataParameter, contextParameter, environmentVarsParameter }, typeof(object), TransformExpression(expr));
+            }
+            catch (Exception ex) when (ex is System.Linq.Dynamic.Core.Exceptions.ParseException || ex is InvalidOperationException)
+            {
+                throw new WorkflowDefinitionLoadException($"Error parsing input expression '{expr}' for property '{input.Key}': {ex.Message}", ex);
+            }
 
             void acn(IStepBody pStep, object pData, IStepExecutionContext pContext)
             {
-                object resolvedValue = sourceExpr.Compile().DynamicInvoke(pData, pContext, Environment.GetEnvironmentVariables());
+                object resolvedValue;
+                try
+                {
+                    resolvedValue = sourceExpr.Compile().DynamicInvoke(pData, pContext, Environment.GetEnvironmentVariables());
+                }
+                catch (TargetInvocationException ex)
+                {
+                    throw new InvalidOperationException($"Error evaluating expression for step property.", ex.InnerException ?? ex);
+                }
                 if (stepProperty.PropertyType.IsEnum)
-                    stepProperty.SetValue(pStep, Enum.Parse(stepProperty.PropertyType, (string)resolvedValue, true));
+                {
+                    try
+                    {
+                        stepProperty.SetValue(pStep, Enum.Parse(stepProperty.PropertyType, resolvedValue?.ToString() ?? string.Empty, true));
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        throw new InvalidOperationException($"Invalid enum value '{resolvedValue}' for property '{stepProperty.Name}' of type '{stepProperty.PropertyType.Name}'.", ex);
+                    }
+                }
                 else
                 {
                     if ((resolvedValue != null) && (stepProperty.PropertyType.IsAssignableFrom(resolvedValue.GetType())))
@@ -391,8 +518,16 @@ namespace WorkflowCore.Services.DefinitionStorage
                     {
                         if (prop.Name.StartsWith("@"))
                         {
-                            var sourceExpr = DynamicExpressionParser.ParseLambda(new[] { dataParameter, contextParameter, environmentVarsParameter }, typeof(object), prop.Value.ToString());
-                            object resolvedValue = sourceExpr.Compile().DynamicInvoke(pData, pContext, Environment.GetEnvironmentVariables());
+                            var sourceExpr = DynamicExpressionParser.ParseLambda(ParsingConfig, false, new[] { dataParameter, contextParameter, environmentVarsParameter }, typeof(object), TransformExpression(prop.Value.ToString()));
+                            object resolvedValue;
+                            try
+                            {
+                                resolvedValue = sourceExpr.Compile().DynamicInvoke(pData, pContext, Environment.GetEnvironmentVariables());
+                            }
+                            catch (TargetInvocationException ex)
+                            {
+                                throw new InvalidOperationException($"Error evaluating expression for step property.", ex.InnerException ?? ex);
+                            }
                             subobj.Remove(prop.Name);
                             subobj.Add(prop.Name.TrimStart('@'), JToken.FromObject(resolvedValue));
                         }

--- a/src/WorkflowCore.DSL/Services/Deserializers.cs
+++ b/src/WorkflowCore.DSL/Services/Deserializers.cs
@@ -1,14 +1,17 @@
-﻿using Newtonsoft.Json;
-using SharpYaml;
 using System;
+using Newtonsoft.Json;
+using SharpYaml.Serialization;
 using WorkflowCore.Models.DefinitionStorage.v1;
 
 namespace WorkflowCore.Services.DefinitionStorage
 {
     public static class Deserializers
     {
-        public static Func<string, DefinitionSourceV1> Json = (source) => JsonConvert.DeserializeObject<DefinitionSourceV1>(source);
+        private static Serializer yamlSerializer = new Serializer();
 
-        public static Func<string, DefinitionSourceV1> Yaml = (source) => YamlSerializer.Deserialize<DefinitionSourceV1>(source);
+        public static Func<string, DefinitionSourceV1> Json = (source) =>
+            JsonConvert.DeserializeObject<DefinitionSourceV1>(source, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None });
+
+        public static Func<string, DefinitionSourceV1> Yaml = (source) => yamlSerializer.DeserializeInto(source, new DefinitionSourceV1());
     }
 }

--- a/src/WorkflowCore.DSL/Services/TypeResolver.cs
+++ b/src/WorkflowCore.DSL/Services/TypeResolver.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WorkflowCore.Interface;
+
+namespace WorkflowCore.Services.DefinitionStorage
+{
+    public class TypeResolver : ITypeResolver
+    {
+        public Type FindType(string name)
+        {
+            try
+            {
+                return Type.GetType(name, true, true);
+            }
+            catch (TypeLoadException ex)
+            {
+                throw new InvalidOperationException($"Could not resolve type '{name}'. Ensure the type exists and the assembly is referenced.", ex);
+            }
+        }
+    }
+}

--- a/src/WorkflowCore.DSL/WorkflowCore.DSL.csproj
+++ b/src/WorkflowCore.DSL/WorkflowCore.DSL.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="SharpYaml" Version="3.7.0" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
+    <PackageReference Include="SharpYaml" Version="1.6.5" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WorkflowCore.Testing/JsonWorkflowTest.cs
+++ b/src/WorkflowCore.Testing/JsonWorkflowTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -17,6 +17,7 @@ namespace WorkflowCore.Testing
         protected IDefinitionLoader DefinitionLoader;
         protected IWorkflowRegistry Registry;
         protected List<StepError> UnhandledStepErrors = new List<StepError>();
+        private ServiceProvider _serviceProvider;
 
         protected virtual void Setup()
         {
@@ -25,16 +26,16 @@ namespace WorkflowCore.Testing
             services.AddLogging();
             ConfigureServices(services);
 
-            var serviceProvider = services.BuildServiceProvider();
+            _serviceProvider = services.BuildServiceProvider();
 
             //config logging
-            var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
+            var loggerFactory = _serviceProvider.GetService<ILoggerFactory>();
             //loggerFactory.AddConsole(LogLevel.Debug);
 
-            PersistenceProvider = serviceProvider.GetService<IPersistenceProvider>();
-            DefinitionLoader = serviceProvider.GetService<IDefinitionLoader>();
-            Registry = serviceProvider.GetService<IWorkflowRegistry>();
-            Host = serviceProvider.GetService<IWorkflowHost>();
+            PersistenceProvider = _serviceProvider.GetService<IPersistenceProvider>();
+            DefinitionLoader = _serviceProvider.GetService<IDefinitionLoader>();
+            Registry = _serviceProvider.GetService<IWorkflowRegistry>();
+            Host = _serviceProvider.GetService<IWorkflowHost>();
             Host.OnStepError += Host_OnStepError;
             Host.Start();
         }
@@ -104,6 +105,7 @@ namespace WorkflowCore.Testing
         public void Dispose()
         {
             Host.Stop();
+            _serviceProvider?.Dispose();
         }
     }
 

--- a/src/WorkflowCore/Exceptions/WorkflowDefinitionLoadException.cs
+++ b/src/WorkflowCore/Exceptions/WorkflowDefinitionLoadException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace WorkflowCore.Exceptions
 {
@@ -6,7 +6,12 @@ namespace WorkflowCore.Exceptions
     {
         public WorkflowDefinitionLoadException(string message)
             : base (message)
-        {            
+        {
+        }
+
+        public WorkflowDefinitionLoadException(string message, Exception innerException)
+            : base(message, innerException)
+        {
         }
     }
 }

--- a/test/WorkflowCore.UnitTests/Services/DefinitionStorage/DefinitionLoaderTests.cs
+++ b/test/WorkflowCore.UnitTests/Services/DefinitionStorage/DefinitionLoaderTests.cs
@@ -19,7 +19,7 @@ namespace WorkflowCore.UnitTests.Services.DefinitionStorage
         public DefinitionLoaderTests()
         {
             _registry = A.Fake<IWorkflowRegistry>();
-            _subject = new DefinitionLoader(_registry);
+            _subject = new DefinitionLoader(_registry, new TypeResolver());
         }
 
         [Fact(DisplayName = "Should register workflow")]


### PR DESCRIPTION
## Summary

Fixes two failing integration tests by aligning `WorkflowCore.DSL` with the equivalent files in `danielgerlag/workflow-core` HEAD.

| Failing test | Root cause (in our fork) |
|---|---|
| `StoredJsonScenario.should_execute_json_workflow_with_dynamic_data` | `System.Linq.Dynamic.Core` 1.6.0+ tightened expression parsing — throws `Method 'Equals' on type 'Object' is not accessible` when parsing expressions against `DynamicData`. Our fork bumped to 1.7.2 via dependabot (commit 8de9121) without porting the accompanying code fix upstream had already made. |
| `StoredYamlScenario` "Execute workflow from stored YAML definition" | `SharpYaml` 3.7.0 is a full rewrite (source-gen first). Its reflection resolver silently does not populate `ExpandoObject` properties, so every step's `Inputs` dictionary parsed as empty. Upstream never bumped SharpYaml past 1.6.5. |

## Approach

Rather than invent fork-local workarounds, adopt upstream's solution verbatim so future pulls merge cleanly:

- Downgrade SharpYaml 3.7.0 → 1.6.5 (matches upstream).
- Downgrade System.Linq.Dynamic.Core 1.7.2 → 1.6.0 (matches upstream).
- Port upstream's DefinitionLoader.cs verbatim, which introduces:
  - ParsingConfig with AllowNewToEvaluateAnyType=false, AreContextKeywordsEnabled=true
  - TransformExpression(string) regex rewriting object.Equals(a, b) for Dynamic.Core 1.6.0+ compatibility
  - try/catch wrapping around every ParseLambda call that throws WorkflowDefinitionLoadException(message, inner)
  - ITypeResolver constructor dependency replacing the inline FindType helper
- Add ITypeResolver + TypeResolver (new files, copied from upstream) and register TypeResolver in AddWorkflowDSL().
- Add the (string, Exception) ctor to WorkflowDefinitionLoadException (upstream already has it) so the new error-wrapping compiles.
- Revert Deserializers.cs to upstream's yamlSerializer.DeserializeInto(source, new DefinitionSourceV1()) API.
- Update DefinitionLoaderTests to pass new TypeResolver() to the DefinitionLoader ctor (only local test change).

All 8 touched files now match danielgerlag/workflow-core HEAD (ref b6bb1a1), so future upstream pulls should be conflict-free on this surface.

## Test plan

- [x] dotnet test test/WorkflowCore.IntegrationTests → 44/44 passed on both net8.0 and net10.0
- [x] dotnet test test/WorkflowCore.UnitTests → 61/61 passed on both net8.0 and net10.0
- [x] dotnet build WorkflowCore.sln → clean
- [ ] Reviewer: verify behavior is unchanged for existing workflows that don't use dynamic data
- [ ] Reviewer: confirm we're OK shedding the SharpYaml 3.7 bump (was there a security/maintenance reason for it that this PR is undoing?)